### PR TITLE
Update 06-flash-led.md

### DIFF
--- a/workshop/06-flash-led.md
+++ b/workshop/06-flash-led.md
@@ -78,6 +78,19 @@
 
 - Exit the program with ctrl+c
 
+Note:
+If using a raspberry Pi 3 you may have an issue with selecting the correct driver, the following will force the raspberry Pi 3 driver.
+Place afer `Console.WriteLine("Hello World")` and overwrite `GpioController controller = new GpioController(PinNumberingScheme.Board);`
+```cs
+    var assembly = typeof(GpioDriver).Assembly;
+    var driverType = assembly.GetType("System.Device.Gpio.Drivers.RaspberryPi3LinuxDriver");
+    var ctor = driverType.GetConstructor(new Type[]{});
+    var driver = ctor.Invoke(null) as GpioDriver;
+    GpioController controller = new GpioController(PinNumberingScheme.Board, driver);
+```
+This code snippet will be required in the next sections.
+
+
 | Previous | Next |
 | -------- | ---- |
 | [< Step 5 - Build the Circuit](05-build-circuit-led-and-button.md) | [Step 7 - Read Button >](07-read-button.md) |


### PR DESCRIPTION
Currently on your Garage course and working "On the Flash LEDs":
https://github.com/pjgpetecodes/rpirobot/blob/main/workshop/06-flash-led.md

I am getting an error using a PIE 3

```
Unhandled exception. System.PlatformNotSupportedException: This driver is generic so it can not perform conversions between pin numbering schemes. at System.Device.Gpio.Drivers.SysFsDriver.ConvertPinNumberToLogicalNumberingScheme(Int32 pinNumber) at System.Device.Gpio.GpioController.GetLogicalPinNumber(Int32 pinNumber) at System.Device.Gpio.GpioController.OpenPinCore(Int32 pinNumber) at System.Device.Gpio.GpioController.OpenPin(Int32 pinNumber) at System.Device.Gpio.GpioController.OpenPin(Int32 pinNumber, PinMode mode) at robot_firmware.Program.Main(String[] args) in /home/pi/share/robot_firmware/Program.cs:line 19
```

You can force the System.Device.Gpio.Drivers.RaspberryPi3LinuxDriver rather than it falling through to the generic

```
         var assembly = typeof(GpioDriver).Assembly;

        var driverType = assembly.GetType("System.Device.Gpio.Drivers.RaspberryPi3LinuxDriver");

         var ctor = driverType.GetConstructor(new Type[]{});

         var driver = ctor.Invoke(null) as GpioDriver;

         GpioController controller = new GpioController(PinNumberingScheme.Board, driver);
```

Maybe just a note for future users if they are still on an old Pi they could just add to all the code:
Solution form here:
https://www.gitmemory.com/issue/dotnet/iot/1329/735402962